### PR TITLE
refactor: centralize LLM message handling across providers

### DIFF
--- a/cmd/kodelet/conversation.go
+++ b/cmd/kodelet/conversation.go
@@ -329,7 +329,7 @@ func showConversationCmd(id string) {
 	}
 
 	// Extract messages from raw message data
-	messages, err := llm.ExtractMessages(record)
+	messages, err := llm.ExtractMessages(record.ModelType, record.RawMessages)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error parsing messages: %v\n", err)
 		os.Exit(1)

--- a/cmd/kodelet/conversation.go
+++ b/cmd/kodelet/conversation.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jingkaihe/kodelet/pkg/conversations"
+	"github.com/jingkaihe/kodelet/pkg/types/llm"
 	"github.com/spf13/cobra"
 )
 
@@ -310,12 +311,6 @@ func deleteConversationCmd(id string) {
 	fmt.Printf("Conversation %s deleted successfully.\n", id)
 }
 
-// Message represents a chat message
-type Message struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
-}
-
 // showConversationCmd displays a specific conversation
 func showConversationCmd(id string) {
 	// Create a store
@@ -362,14 +357,14 @@ func showConversationCmd(id string) {
 }
 
 // extractMessages parses the raw messages from a conversation record
-func extractMessages(rawMessages json.RawMessage) ([]Message, error) {
+func extractMessages(rawMessages json.RawMessage) ([]llm.Message, error) {
 	// Parse the raw JSON messages directly
 	var rawMsgs []map[string]interface{}
 	if err := json.Unmarshal(rawMessages, &rawMsgs); err != nil {
 		return nil, fmt.Errorf("error parsing raw messages: %v", err)
 	}
 
-	var messages []Message
+	var messages []llm.Message
 	for _, msg := range rawMsgs {
 		role, ok := msg["role"].(string)
 		if !ok {
@@ -403,7 +398,7 @@ func extractMessages(rawMessages json.RawMessage) ([]Message, error) {
 					continue // Skip if text is not a string or doesn't exist
 				}
 
-				messages = append(messages, Message{
+				messages = append(messages, llm.Message{
 					Role:    role,
 					Content: text,
 				})
@@ -420,7 +415,7 @@ func extractMessages(rawMessages json.RawMessage) ([]Message, error) {
 					continue // Skip if marshaling fails
 				}
 
-				messages = append(messages, Message{
+				messages = append(messages, llm.Message{
 					Role:    role,
 					Content: fmt.Sprintf("🔧 Using tool: %s", string(inputJSON)),
 				})
@@ -443,7 +438,7 @@ func extractMessages(rawMessages json.RawMessage) ([]Message, error) {
 						continue // Skip if text is not a string
 					}
 
-					messages = append(messages, Message{
+					messages = append(messages, llm.Message{
 						Role:    "assistant",
 						Content: fmt.Sprintf("🔄 Tool result: %s", result),
 					})
@@ -456,7 +451,7 @@ func extractMessages(rawMessages json.RawMessage) ([]Message, error) {
 					continue // Skip if thinking is not a string
 				}
 
-				messages = append(messages, Message{
+				messages = append(messages, llm.Message{
 					Role:    "assistant",
 					Content: fmt.Sprintf("💭 Thinking: %s", thinking),
 				})
@@ -468,7 +463,7 @@ func extractMessages(rawMessages json.RawMessage) ([]Message, error) {
 }
 
 // displayConversation renders the messages in a readable text format
-func displayConversation(messages []Message) {
+func displayConversation(messages []llm.Message) {
 	for i, msg := range messages {
 		// Add a separator between messages
 		if i > 0 {

--- a/pkg/llm/anthropic/anthropic.go
+++ b/pkg/llm/anthropic/anthropic.go
@@ -577,8 +577,12 @@ func (t *AnthropicThread) IsPersisted() bool {
 }
 
 // GetMessages returns the current messages in the thread
-func (t *AnthropicThread) GetMessages() []anthropic.MessageParam {
-	return t.messages
+func (t *AnthropicThread) GetMessages() ([]llmtypes.Message, error) {
+	b, err := json.Marshal(t.messages)
+	if err != nil {
+		return nil, err
+	}
+	return ExtractMessages(b)
 }
 
 // EnablePersistence enables conversation persistence for this thread

--- a/pkg/llm/anthropic/anthropic.go
+++ b/pkg/llm/anthropic/anthropic.go
@@ -115,6 +115,10 @@ type AnthropicThread struct {
 	conversationMu sync.Mutex
 }
 
+func (t *AnthropicThread) Provider() string {
+	return "anthropic"
+}
+
 // NewAnthropicThread creates a new thread with Anthropic's Claude API
 func NewAnthropicThread(config llmtypes.Config) *AnthropicThread {
 	// Apply defaults if not provided

--- a/pkg/llm/anthropic/persistence.go
+++ b/pkg/llm/anthropic/persistence.go
@@ -9,6 +9,7 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/packages/param"
 	"github.com/jingkaihe/kodelet/pkg/conversations"
+	"github.com/jingkaihe/kodelet/pkg/types/llm"
 )
 
 // SaveConversation saves the current thread to the conversation store
@@ -190,4 +191,110 @@ func (t *AnthropicThread) DeserializeMessages(b []byte) ([]anthropic.MessagePara
 	}
 
 	return t.messages, nil
+}
+
+// ExtractMessages parses the raw messages from a conversation record
+func ExtractMessages(rawMessages json.RawMessage) ([]llm.Message, error) {
+	// Parse the raw JSON messages directly
+	var rawMsgs []map[string]interface{}
+	if err := json.Unmarshal(rawMessages, &rawMsgs); err != nil {
+		return nil, fmt.Errorf("error parsing raw messages: %v", err)
+	}
+
+	var messages []llm.Message
+	for _, msg := range rawMsgs {
+		role, ok := msg["role"].(string)
+		if !ok {
+			continue // Skip if role is not a string or doesn't exist
+		}
+
+		content, ok := msg["content"].([]interface{})
+		if !ok || len(content) == 0 {
+			continue // Skip if content is not an array or is empty
+		}
+
+		// Process each content block in the message
+		for _, block := range content {
+			blockMap, ok := block.(map[string]interface{})
+			if !ok {
+				continue // Skip if block is not a map
+			}
+
+			// Extract block type
+			blockType, ok := blockMap["type"].(string)
+			if !ok {
+				continue // Skip if type is not a string or doesn't exist
+			}
+
+			// Extract message content based on block type
+			switch blockType {
+			case "text":
+				// Add text content
+				text, ok := blockMap["text"].(string)
+				if !ok {
+					continue // Skip if text is not a string or doesn't exist
+				}
+
+				messages = append(messages, llm.Message{
+					Role:    role,
+					Content: text,
+				})
+
+			case "tool_use":
+				// Add tool usage as content
+				input, ok := blockMap["input"]
+				if !ok {
+					continue // Skip if input is not found
+				}
+
+				inputJSON, err := json.Marshal(input)
+				if err != nil {
+					continue // Skip if marshaling fails
+				}
+
+				messages = append(messages, llm.Message{
+					Role:    role,
+					Content: fmt.Sprintf("🔧 Using tool: %s", string(inputJSON)),
+				})
+
+			case "tool_result":
+				// Add tool result as content
+				resultContent, ok := blockMap["content"].([]interface{})
+				if !ok || len(resultContent) == 0 {
+					continue // Skip if content is not an array or is empty
+				}
+
+				resultBlock, ok := resultContent[0].(map[string]interface{})
+				if !ok {
+					continue // Skip if first element is not a map
+				}
+
+				if resultBlock["type"] == "text" {
+					result, ok := resultBlock["text"].(string)
+					if !ok {
+						continue // Skip if text is not a string
+					}
+
+					messages = append(messages, llm.Message{
+						Role:    "assistant",
+						Content: fmt.Sprintf("🔄 Tool result: %s", result),
+					})
+				}
+
+			case "thinking":
+				// Add thinking content
+				thinking, ok := blockMap["thinking"].(string)
+				if !ok {
+					continue // Skip if thinking is not a string
+				}
+
+				messages = append(messages, llm.Message{
+					Role:    "assistant",
+					Content: fmt.Sprintf("💭 Thinking: %s", thinking),
+				})
+			}
+		}
+	}
+
+	return messages, nil
 }

--- a/pkg/llm/anthropic/persistence.go
+++ b/pkg/llm/anthropic/persistence.go
@@ -70,9 +70,11 @@ func (t *AnthropicThread) loadConversation() error {
 	}
 
 	// Reset current messages
-	if _, err := t.DeserializeMessages(record.RawMessages); err != nil {
+	messages, err := DeserializeMessages(record.RawMessages)
+	if err != nil {
 		return fmt.Errorf("failed to deserialize conversation messages: %w", err)
 	}
+	t.messages = messages
 
 	// Restore usage statistics
 	t.usage = &record.Usage
@@ -87,8 +89,8 @@ type messageParam struct {
 	Content []contentBlock `json:"content"`
 }
 
-func (t *AnthropicThread) DeserializeMessages(b []byte) ([]anthropic.MessageParam, error) {
-	t.messages = []anthropic.MessageParam{}
+func DeserializeMessages(b []byte) ([]anthropic.MessageParam, error) {
+	messages := []anthropic.MessageParam{}
 	var listRawMessages []json.RawMessage
 	if err := json.Unmarshal(b, &listRawMessages); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal conversation messages: %w", err)
@@ -186,11 +188,11 @@ func (t *AnthropicThread) DeserializeMessages(b []byte) ([]anthropic.MessagePara
 		}
 
 		if len(msg.Content) != 0 {
-			t.messages = append(t.messages, msg)
+			messages = append(messages, msg)
 		}
 	}
 
-	return t.messages, nil
+	return messages, nil
 }
 
 // ExtractMessages parses the raw messages from a conversation record

--- a/pkg/llm/anthropic/persistence_test.go
+++ b/pkg/llm/anthropic/persistence_test.go
@@ -16,9 +16,9 @@ func TestDeserializeMessages(t *testing.T) {
 	thread := NewAnthropicThread(llmtypes.Config{
 		Model: anthropic.ModelClaude3_7SonnetLatest,
 	})
-	thread.DeserializeMessages([]byte(``))
-
-	assert.Equal(t, 0, len(thread.messages))
+	messages, err := DeserializeMessages([]byte(`[]`))
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(messages))
 
 	rawMessages := `[
     {
@@ -75,12 +75,14 @@ func TestDeserializeMessages(t *testing.T) {
     }
   ]`
 
-	thread.DeserializeMessages([]byte(rawMessages))
+	messages, err = DeserializeMessages([]byte(rawMessages))
+	assert.NoError(t, err)
+	thread.messages = messages
 
-	assert.Equal(t, 3, len(thread.messages)) // remove the empty assistant message
-	assert.Equal(t, anthropic.MessageParamRoleUser, thread.messages[0].Role)
-	assert.Equal(t, "ls -la", thread.messages[0].Content[0].OfRequestTextBlock.Text)
-	assert.Equal(t, "text", *thread.messages[0].Content[0].GetType())
+	assert.Equal(t, 3, len(messages)) // remove the empty assistant message
+	assert.Equal(t, anthropic.MessageParamRoleUser, messages[0].Role)
+	assert.Equal(t, "ls -la", messages[0].Content[0].OfRequestTextBlock.Text)
+	assert.Equal(t, "text", *messages[0].Content[0].GetType())
 	assert.Equal(t, anthropic.CacheControlEphemeralParam{}, thread.messages[0].Content[0].OfRequestTextBlock.CacheControl, "prompt cache config is ignored")
 
 	assert.Equal(t, anthropic.MessageParamRoleAssistant, thread.messages[1].Role)

--- a/pkg/llm/thread.go
+++ b/pkg/llm/thread.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/jingkaihe/kodelet/pkg/conversations"
 	"github.com/jingkaihe/kodelet/pkg/llm/anthropic"
 	llmtypes "github.com/jingkaihe/kodelet/pkg/types/llm"
 	tooltypes "github.com/jingkaihe/kodelet/pkg/types/tools"
@@ -58,10 +57,10 @@ func SendMessageAndGetText(ctx context.Context, state tooltypes.State, query str
 }
 
 // ExtractMessages parses the raw messages from a conversation record
-func ExtractMessages(record conversations.ConversationRecord) ([]llmtypes.Message, error) {
-	if record.ModelType == "anthropic" {
-		return anthropic.ExtractMessages(record.RawMessages)
+func ExtractMessages(provider string, rawMessages []byte) ([]llmtypes.Message, error) {
+	if provider == "anthropic" {
+		return anthropic.ExtractMessages(rawMessages)
 	}
 
-	return nil, fmt.Errorf("unsupported model type: %s", record.ModelType)
+	return nil, fmt.Errorf("unsupported model type: %s", provider)
 }

--- a/pkg/llm/thread.go
+++ b/pkg/llm/thread.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/jingkaihe/kodelet/pkg/conversations"
 	"github.com/jingkaihe/kodelet/pkg/llm/anthropic"
 	llmtypes "github.com/jingkaihe/kodelet/pkg/types/llm"
 	tooltypes "github.com/jingkaihe/kodelet/pkg/types/tools"
@@ -54,4 +55,13 @@ func SendMessageAndGetTextWithUsage(ctx context.Context, state tooltypes.State, 
 func SendMessageAndGetText(ctx context.Context, state tooltypes.State, query string, config llmtypes.Config, silent bool, opt llmtypes.MessageOpt) string {
 	text, _ := SendMessageAndGetTextWithUsage(ctx, state, query, config, silent, opt)
 	return text
+}
+
+// ExtractMessages parses the raw messages from a conversation record
+func ExtractMessages(record conversations.ConversationRecord) ([]llmtypes.Message, error) {
+	if record.ModelType == "anthropic" {
+		return anthropic.ExtractMessages(record.RawMessages)
+	}
+
+	return nil, fmt.Errorf("unsupported model type: %s", record.ModelType)
 }

--- a/pkg/tui/assistant.go
+++ b/pkg/tui/assistant.go
@@ -39,39 +39,39 @@ func NewAssistantClient(ctx context.Context, conversationID string, enablePersis
 }
 
 // GetThreadMessages returns the messages from the thread
-func (a *AssistantClient) GetThreadMessages() ([]Message, error) {
+func (a *AssistantClient) GetThreadMessages() ([]llmtypes.Message, error) {
 	// Get access to the underlying anthropic thread to extract messages
 	if anthropicThread, ok := a.thread.(*anthropic.AnthropicThread); ok {
 		msgParams := anthropicThread.GetMessages()
-		var messages []Message
+		var messages []llmtypes.Message
 
 		for _, msgParam := range msgParams {
 			for _, block := range msgParam.Content {
 				blockType := *block.GetType()
 				switch blockType {
 				case "text":
-					messages = append(messages, Message{
+					messages = append(messages, llmtypes.Message{
 						Content: *block.GetText(),
-						IsUser:  msgParam.Role == "user",
+						Role:    "user",
 					})
 				case "tool_use":
 					inputJSON, _ := json.Marshal(block.OfRequestToolUseBlock.Input)
-					messages = append(messages, Message{
+					messages = append(messages, llmtypes.Message{
 						Content: fmt.Sprintf("🔧 Using tool: %s", string(inputJSON)),
-						IsUser:  msgParam.Role == "user",
+						Role:    "user",
 					})
 				case "tool_result":
 					if len(block.OfRequestToolResultBlock.Content) > 0 {
 						result := block.OfRequestToolResultBlock.Content[0].OfRequestTextBlock.Text
-						messages = append(messages, Message{
+						messages = append(messages, llmtypes.Message{
 							Content: fmt.Sprintf("🔄 Tool result: %s", result),
-							IsUser:  false,
+							Role:    "assistant",
 						})
 					}
 				case "thinking":
-					messages = append(messages, Message{
+					messages = append(messages, llmtypes.Message{
 						Content: fmt.Sprintf("💭 Thinking: %s", block.OfRequestThinkingBlock.Thinking),
-						IsUser:  false,
+						Role:    "assistant",
 					})
 				}
 			}

--- a/pkg/types/llm/thread.go
+++ b/pkg/types/llm/thread.go
@@ -52,4 +52,6 @@ type Thread interface {
 	IsPersisted() bool
 	// EnablePersistence enables conversation persistence for this thread
 	EnablePersistence(enabled bool)
+	// Provider returns the provider of the thread
+	Provider() string
 }

--- a/pkg/types/llm/thread.go
+++ b/pkg/types/llm/thread.go
@@ -6,6 +6,12 @@ import (
 	tooltypes "github.com/jingkaihe/kodelet/pkg/types/tools"
 )
 
+// Message represents a chat message
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
 // MessageOpt represents options for sending messages
 type MessageOpt struct {
 	// PromptCache indicates if prompt caching should be used

--- a/pkg/types/llm/thread.go
+++ b/pkg/types/llm/thread.go
@@ -54,4 +54,6 @@ type Thread interface {
 	EnablePersistence(enabled bool)
 	// Provider returns the provider of the thread
 	Provider() string
+	// GetMessages returns the messages from the thread
+	GetMessages() ([]Message, error)
 }


### PR DESCRIPTION
## Description
Refactors the LLM domain to centralize message type definitions and extraction logic, improving modularity and provider abstraction.
## Changes
- Move the Message type to the central llm types package
- Add Provider() method to Thread interface to identify LLM provider
- Refactor message extraction logic to work with multiple providers
- Separate message deserialization from thread state management
- Update TUI and conversation commands to use the centralized message types
- Add proper extraction of structured messages from raw conversation data
## Impact
- Improves code organization by centralizing LLM message handling
- Enhances extensibility for supporting multiple LLM providers
- Reduces duplication of message parsing logic
- Simplifies the conversation display and management interface