### PR TITLE
feat(conversations): persist and display user-facing tool results

### DIFF
--- a/cmd/kodelet/conversation.go
+++ b/cmd/kodelet/conversation.go
@@ -433,7 +433,7 @@ func showConversationCmd(ctx context.Context, id string, config *ConversationSho
 		fmt.Println(string(outputJSON))
 	case "text":
 		// Format as readable text with user/assistant prefixes
-		displayConversation(messages)
+		displayConversation(messages, record.UserFacingToolResults)
 	default:
 		presenter.Error(fmt.Errorf("unsupported format: %s", config.Format), "Unknown format. Supported formats are raw, json, and text")
 		os.Exit(1)
@@ -441,7 +441,7 @@ func showConversationCmd(ctx context.Context, id string, config *ConversationSho
 }
 
 // displayConversation renders the messages in a readable text format
-func displayConversation(messages []llmtypes.Message) {
+func displayConversation(messages []llmtypes.Message, userFacingToolResults map[string]string) {
 	for i, msg := range messages {
 		// Add a separator between messages
 		if i > 0 {
@@ -467,5 +467,15 @@ func displayConversation(messages []llmtypes.Message) {
 		// Output the formatted message with section header
 		presenter.Section(roleLabel)
 		fmt.Printf("%s\n", msg.Content)
+	}
+
+	// Display user-facing tool results if any exist
+	if len(userFacingToolResults) > 0 {
+		presenter.Separator()
+		presenter.Section("Tool Results (User-Facing)")
+		for toolCallID, result := range userFacingToolResults {
+			fmt.Printf("Tool Call ID: %s\n", toolCallID)
+			fmt.Printf("%s\n\n", result)
+		}
 	}
 }

--- a/pkg/conversations/conversation.go
+++ b/pkg/conversations/conversation.go
@@ -10,15 +10,16 @@ import (
 
 // ConversationRecord represents a persisted conversation with its messages and metadata
 type ConversationRecord struct {
-	ID             string                 `json:"id"`
-	RawMessages    json.RawMessage        `json:"rawMessages"` // Raw LLM provider messages
-	ModelType      string                 `json:"modelType"`   // e.g., "anthropic"
-	FileLastAccess map[string]time.Time   `json:"fileLastAccess"`
-	Usage          llmtypes.Usage         `json:"usage"`
-	Summary        string                 `json:"summary,omitempty"`
-	CreatedAt      time.Time              `json:"createdAt"`
-	UpdatedAt      time.Time              `json:"updatedAt"`
-	Metadata       map[string]interface{} `json:"metadata,omitempty"`
+	ID                     string                 `json:"id"`
+	RawMessages            json.RawMessage        `json:"rawMessages"` // Raw LLM provider messages
+	ModelType              string                 `json:"modelType"`   // e.g., "anthropic"
+	FileLastAccess         map[string]time.Time   `json:"fileLastAccess"`
+	Usage                  llmtypes.Usage         `json:"usage"`
+	Summary                string                 `json:"summary,omitempty"`
+	CreatedAt              time.Time              `json:"createdAt"`
+	UpdatedAt              time.Time              `json:"updatedAt"`
+	Metadata               map[string]interface{} `json:"metadata,omitempty"`
+	UserFacingToolResults  map[string]string      `json:"userFacingToolResults,omitempty"` // Maps tool_call_id to user-facing result
 }
 
 // ConversationSummary provides a brief overview of a conversation
@@ -41,12 +42,13 @@ func NewConversationRecord(id string) ConversationRecord {
 	}
 
 	return ConversationRecord{
-		ID:             id,
-		RawMessages:    json.RawMessage("[]"),
-		CreatedAt:      now,
-		UpdatedAt:      now,
-		Metadata:       make(map[string]interface{}),
-		FileLastAccess: make(map[string]time.Time),
+		ID:                    id,
+		RawMessages:           json.RawMessage("[]"),
+		CreatedAt:             now,
+		UpdatedAt:             now,
+		Metadata:              make(map[string]interface{}),
+		FileLastAccess:        make(map[string]time.Time),
+		UserFacingToolResults: make(map[string]string),
 	}
 }
 

--- a/pkg/llm/anthropic/anthropic.go
+++ b/pkg/llm/anthropic/anthropic.go
@@ -41,18 +41,19 @@ const (
 
 // AnthropicThread implements the Thread interface using Anthropic's Claude API
 type AnthropicThread struct {
-	client          anthropic.Client
-	config          llmtypes.Config
-	state           tooltypes.State
-	messages        []anthropic.MessageParam
-	usage           *llmtypes.Usage
-	conversationID  string
-	summary         string
-	isPersisted     bool
-	store           ConversationStore
-	mu              sync.Mutex
-	conversationMu  sync.Mutex
-	useSubscription bool
+	client                anthropic.Client
+	config                llmtypes.Config
+	state                 tooltypes.State
+	messages              []anthropic.MessageParam
+	usage                 *llmtypes.Usage
+	conversationID        string
+	summary               string
+	isPersisted           bool
+	store                 ConversationStore
+	mu                    sync.Mutex
+	conversationMu        sync.Mutex
+	useSubscription       bool
+	userFacingToolResults map[string]string // Maps tool_call_id to user-facing result
 }
 
 func (t *AnthropicThread) Provider() string {
@@ -126,12 +127,13 @@ func NewAnthropicThread(config llmtypes.Config) (*AnthropicThread, error) {
 	}
 
 	return &AnthropicThread{
-		client:          client,
-		config:          config,
-		useSubscription: useSubscription,
-		conversationID:  conversations.GenerateID(),
-		isPersisted:     false,
-		usage:           &llmtypes.Usage{}, // must be initialised to avoid nil pointer dereference
+		client:                client,
+		config:                config,
+		useSubscription:       useSubscription,
+		conversationID:        conversations.GenerateID(),
+		isPersisted:           false,
+		usage:                 &llmtypes.Usage{}, // must be initialised to avoid nil pointer dereference
+		userFacingToolResults: make(map[string]string),
 	}, nil
 }
 
@@ -403,6 +405,9 @@ func (t *AnthropicThread) processMessageExchange(
 			runToolCtx := t.WithSubAgent(ctx, handler)
 			output := tools.RunTool(runToolCtx, t.state, block.Name, string(variant.JSON.Input.Raw()))
 			handler.HandleToolResult(block.Name, output.UserFacing())
+			
+			// Store the user-facing result for this tool call
+			t.SetUserFacingToolResult(block.ID, output.UserFacing())
 
 			// For tracing, add tool execution completion event
 			telemetry.AddEvent(ctx, "tool_execution_complete",
@@ -635,12 +640,13 @@ func (t *AnthropicThread) NewSubAgent(ctx context.Context) llmtypes.Thread {
 
 	// Create subagent thread reusing the parent's client instead of creating a new one
 	thread := &AnthropicThread{
-		client:          t.client, // Reuse parent's client
-		config:          config,
-		useSubscription: t.useSubscription, // Reuse parent's subscription status
-		conversationID:  conversations.GenerateID(),
-		isPersisted:     false,   // subagent is not persisted
-		usage:           t.usage, // Share usage tracking with parent
+		client:                t.client, // Reuse parent's client
+		config:                config,
+		useSubscription:       t.useSubscription, // Reuse parent's subscription status
+		conversationID:        conversations.GenerateID(),
+		isPersisted:           false,   // subagent is not persisted
+		usage:                 t.usage, // Share usage tracking with parent
+		userFacingToolResults: make(map[string]string),
 	}
 
 	thread.SetState(tools.NewBasicState(ctx, tools.WithSubAgentTools(), tools.WithExtraMCPTools(t.state.MCPTools())))
@@ -865,5 +871,44 @@ func getMediaTypeFromExtension(ext string) (anthropic.Base64ImageSourceMediaType
 		return anthropic.Base64ImageSourceMediaTypeImageWebP, nil
 	default:
 		return "", fmt.Errorf("unsupported format")
+	}
+}
+
+// SetUserFacingToolResult stores the user-facing result for a tool call
+func (t *AnthropicThread) SetUserFacingToolResult(toolCallID, result string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.userFacingToolResults == nil {
+		t.userFacingToolResults = make(map[string]string)
+	}
+	t.userFacingToolResults[toolCallID] = result
+}
+
+// GetUserFacingToolResults returns all user-facing tool results
+func (t *AnthropicThread) GetUserFacingToolResults() map[string]string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.userFacingToolResults == nil {
+		return make(map[string]string)
+	}
+	// Return a copy to avoid race conditions
+	result := make(map[string]string)
+	for k, v := range t.userFacingToolResults {
+		result[k] = v
+	}
+	return result
+}
+
+// SetUserFacingToolResults sets all user-facing tool results (for loading from conversation)
+func (t *AnthropicThread) SetUserFacingToolResults(results map[string]string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if results == nil {
+		t.userFacingToolResults = make(map[string]string)
+	} else {
+		t.userFacingToolResults = make(map[string]string)
+		for k, v := range results {
+			t.userFacingToolResults[k] = v
+		}
 	}
 }

--- a/pkg/llm/anthropic/persistence.go
+++ b/pkg/llm/anthropic/persistence.go
@@ -73,15 +73,16 @@ func (t *AnthropicThread) SaveConversation(ctx context.Context, summarise bool) 
 
 	// Create a new conversation record
 	record := conversations.ConversationRecord{
-		ID:             t.conversationID,
-		RawMessages:    rawMessages,
-		ModelType:      "anthropic",
-		Usage:          *t.usage,
-		Metadata:       map[string]interface{}{"model": t.config.Model},
-		Summary:        t.summary,
-		CreatedAt:      time.Now(),
-		UpdatedAt:      time.Now(),
-		FileLastAccess: t.state.FileLastAccess(),
+		ID:                    t.conversationID,
+		RawMessages:           rawMessages,
+		ModelType:             "anthropic",
+		Usage:                 *t.usage,
+		Metadata:              map[string]interface{}{"model": t.config.Model},
+		Summary:               t.summary,
+		CreatedAt:             time.Now(),
+		UpdatedAt:             time.Now(),
+		FileLastAccess:        t.state.FileLastAccess(),
+		UserFacingToolResults: t.GetUserFacingToolResults(),
 	}
 
 	// Save the record
@@ -120,6 +121,8 @@ func (t *AnthropicThread) loadConversation() error {
 	t.usage = &record.Usage
 	t.summary = record.Summary
 	t.state.SetFileLastAccess(record.FileLastAccess)
+	// Restore user-facing tool results
+	t.SetUserFacingToolResults(record.UserFacingToolResults)
 	return nil
 }
 

--- a/pkg/llm/openai/openai.go
+++ b/pkg/llm/openai/openai.go
@@ -222,18 +222,19 @@ func getModelPricing(model string) ModelPricing {
 
 // OpenAIThread implements the Thread interface using OpenAI's API
 type OpenAIThread struct {
-	client          *openai.Client
-	config          llmtypes.Config
-	reasoningEffort string // low, medium, high to determine token allocation
-	state           tooltypes.State
-	messages        []openai.ChatCompletionMessage
-	usage           *llmtypes.Usage
-	conversationID  string
-	summary         string
-	isPersisted     bool
-	store           ConversationStore
-	mu              sync.Mutex
-	conversationMu  sync.Mutex
+	client                *openai.Client
+	config                llmtypes.Config
+	reasoningEffort       string // low, medium, high to determine token allocation
+	state                 tooltypes.State
+	messages              []openai.ChatCompletionMessage
+	usage                 *llmtypes.Usage
+	conversationID        string
+	summary               string
+	isPersisted           bool
+	store                 ConversationStore
+	mu                    sync.Mutex
+	conversationMu        sync.Mutex
+	userFacingToolResults map[string]string // Maps tool_call_id to user-facing result
 }
 
 func (t *OpenAIThread) Provider() string {
@@ -256,12 +257,13 @@ func NewOpenAIThread(config llmtypes.Config) *OpenAIThread {
 	}
 
 	return &OpenAIThread{
-		client:          openai.NewClient(os.Getenv("OPENAI_API_KEY")), // API key will be set via env var
-		config:          config,
-		reasoningEffort: reasoningEffort,
-		conversationID:  conversations.GenerateID(),
-		isPersisted:     false,
-		usage:           &llmtypes.Usage{}, // must be initialized to avoid nil pointer dereference
+		client:                openai.NewClient(os.Getenv("OPENAI_API_KEY")), // API key will be set via env var
+		config:                config,
+		reasoningEffort:       reasoningEffort,
+		conversationID:        conversations.GenerateID(),
+		isPersisted:           false,
+		usage:                 &llmtypes.Usage{}, // must be initialized to avoid nil pointer dereference
+		userFacingToolResults: make(map[string]string),
 	}
 }
 
@@ -521,6 +523,9 @@ func (t *OpenAIThread) processMessageExchange(
 		runToolCtx := t.WithSubAgent(ctx, handler)
 		output := tools.RunTool(runToolCtx, t.state, toolCall.Function.Name, toolCall.Function.Arguments)
 		handler.HandleToolResult(toolCall.Function.Name, output.UserFacing())
+		
+		// Store the user-facing result for this tool call
+		t.SetUserFacingToolResult(toolCall.ID, output.UserFacing())
 
 		// For tracing, add tool execution completion event
 		telemetry.AddEvent(ctx, "tool_execution_complete",
@@ -576,12 +581,13 @@ func (t *OpenAIThread) NewSubAgent(ctx context.Context) llmtypes.Thread {
 
 	// Create subagent thread reusing the parent's client instead of creating a new one
 	thread := &OpenAIThread{
-		client:          t.client, // Reuse parent's client
-		config:          config,
-		reasoningEffort: t.reasoningEffort, // Reuse parent's reasoning effort
-		conversationID:  conversations.GenerateID(),
-		isPersisted:     false,   // subagent is not persisted
-		usage:           t.usage, // Share usage tracking with parent
+		client:                t.client, // Reuse parent's client
+		config:                config,
+		reasoningEffort:       t.reasoningEffort, // Reuse parent's reasoning effort
+		conversationID:        conversations.GenerateID(),
+		isPersisted:           false,   // subagent is not persisted
+		usage:                 t.usage, // Share usage tracking with parent
+		userFacingToolResults: make(map[string]string),
 	}
 
 	thread.SetState(tools.NewBasicState(ctx, tools.WithSubAgentTools(), tools.WithExtraMCPTools(t.state.MCPTools())))
@@ -832,5 +838,44 @@ func getImageMediaType(ext string) (string, error) {
 		return "image/webp", nil
 	default:
 		return "", fmt.Errorf("unsupported format")
+	}
+}
+
+// SetUserFacingToolResult stores the user-facing result for a tool call
+func (t *OpenAIThread) SetUserFacingToolResult(toolCallID, result string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.userFacingToolResults == nil {
+		t.userFacingToolResults = make(map[string]string)
+	}
+	t.userFacingToolResults[toolCallID] = result
+}
+
+// GetUserFacingToolResults returns all user-facing tool results
+func (t *OpenAIThread) GetUserFacingToolResults() map[string]string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.userFacingToolResults == nil {
+		return make(map[string]string)
+	}
+	// Return a copy to avoid race conditions
+	result := make(map[string]string)
+	for k, v := range t.userFacingToolResults {
+		result[k] = v
+	}
+	return result
+}
+
+// SetUserFacingToolResults sets all user-facing tool results (for loading from conversation)
+func (t *OpenAIThread) SetUserFacingToolResults(results map[string]string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if results == nil {
+		t.userFacingToolResults = make(map[string]string)
+	} else {
+		t.userFacingToolResults = make(map[string]string)
+		for k, v := range results {
+			t.userFacingToolResults[k] = v
+		}
 	}
 }

--- a/pkg/llm/openai/persistence.go
+++ b/pkg/llm/openai/persistence.go
@@ -65,15 +65,16 @@ func (t *OpenAIThread) SaveConversation(ctx context.Context, summarize bool) err
 
 	// Build the conversation record
 	record := conversations.ConversationRecord{
-		ID:             t.conversationID,
-		RawMessages:    messagesJSON,
-		ModelType:      "openai",
-		Usage:          *t.usage,
-		Metadata:       map[string]interface{}{"model": t.config.Model},
-		Summary:        t.summary,
-		CreatedAt:      time.Now(),
-		UpdatedAt:      time.Now(),
-		FileLastAccess: t.state.FileLastAccess(),
+		ID:                    t.conversationID,
+		RawMessages:           messagesJSON,
+		ModelType:             "openai",
+		Usage:                 *t.usage,
+		Metadata:              map[string]interface{}{"model": t.config.Model},
+		Summary:               t.summary,
+		CreatedAt:             time.Now(),
+		UpdatedAt:             time.Now(),
+		FileLastAccess:        t.state.FileLastAccess(),
+		UserFacingToolResults: t.GetUserFacingToolResults(),
 	}
 
 	// Save to the store
@@ -112,6 +113,8 @@ func (t *OpenAIThread) loadConversation() error {
 	t.usage = &record.Usage
 	t.summary = record.Summary
 	t.state.SetFileLastAccess(record.FileLastAccess)
+	// Restore user-facing tool results
+	t.SetUserFacingToolResults(record.UserFacingToolResults)
 
 	return nil
 }

--- a/pkg/tools/image_recognition_test.go
+++ b/pkg/tools/image_recognition_test.go
@@ -228,6 +228,9 @@ func (m *mockThread) IsPersisted() bool                                         
 func (m *mockThread) EnablePersistence(enabled bool)                                           {}
 func (m *mockThread) Provider() string                                                         { return "mock" }
 func (m *mockThread) GetMessages() ([]llm.Message, error)                                      { return nil, nil }
+func (m *mockThread) SetUserFacingToolResult(toolCallID, result string)                        {}
+func (m *mockThread) GetUserFacingToolResults() map[string]string                              { return make(map[string]string) }
+func (m *mockThread) SetUserFacingToolResults(results map[string]string)                       {}
 
 func TestImageRecognitionTool_Execute(t *testing.T) {
 	tool := &ImageRecognitionTool{}

--- a/pkg/tools/web_fetch_test.go
+++ b/pkg/tools/web_fetch_test.go
@@ -572,6 +572,18 @@ func (m *MockThread) GetMessages() ([]llm.Message, error) {
 	return []llm.Message{}, nil
 }
 
+func (m *MockThread) SetUserFacingToolResult(toolCallID, result string) {
+	// Mock implementation - do nothing
+}
+
+func (m *MockThread) GetUserFacingToolResults() map[string]string {
+	return make(map[string]string)
+}
+
+func (m *MockThread) SetUserFacingToolResults(results map[string]string) {
+	// Mock implementation - do nothing
+}
+
 func (m *MockThread) Reset() {
 	m.called = false
 	m.lastPrompt = ""

--- a/pkg/types/llm/thread.go
+++ b/pkg/types/llm/thread.go
@@ -61,4 +61,10 @@ type Thread interface {
 	Provider() string
 	// GetMessages returns the messages from the thread
 	GetMessages() ([]Message, error)
+	// SetUserFacingToolResult stores the user-facing result for a tool call
+	SetUserFacingToolResult(toolCallID, result string)
+	// GetUserFacingToolResults returns all user-facing tool results
+	GetUserFacingToolResults() map[string]string
+	// SetUserFacingToolResults sets all user-facing tool results (for loading from conversation)
+	SetUserFacingToolResults(results map[string]string)
 }


### PR DESCRIPTION
## Description
This feature enhances conversation functionality by persisting and displaying user-facing tool results. When tools are executed during conversations, their user-facing outputs are now stored alongside the conversation history and can be viewed when reviewing past conversations.

## Changes
- Added  field to  struct to store tool execution results
- Extended  interface with methods for managing user-facing tool results (, , )
- Updated both Anthropic and OpenAI thread implementations to track and persist tool results with thread-safe access
- Enhanced conversation display functionality to show stored tool results in a dedicated section
- Modified persistence layer to save and load user-facing tool results across conversation sessions
- Updated test mocks to satisfy the extended Thread interface

## Impact
- Improves conversation history preservation by maintaining tool execution context
- Enables better debugging and review capabilities for past tool executions
- Enhances user experience when reviewing conversation history with full context
- Maintains full backward compatibility through optional fields and graceful handling of missing data