### PR TITLE
feat(openai): add retry mechanism for API calls with configurable backoff strategy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.2
 require (
 	github.com/JohannesKaufmann/html-to-markdown v1.6.0
 	github.com/anthropics/anthropic-sdk-go v1.4.0
+	github.com/avast/retry-go/v4 v4.6.1
 	github.com/aymanbagabas/go-udiff v0.2.0
 	github.com/bmatcuk/doublestar/v4 v4.8.1
 	github.com/charmbracelet/bubbles v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/anthropics/anthropic-sdk-go v1.4.0 h1:fU1jKxYbQdQDiEXCxeW5XZRIOwKevn/
 github.com/anthropics/anthropic-sdk-go v1.4.0/go.mod h1:AapDW22irxK2PSumZiQXYUFvsdQgkwIWlpESweWZI/c=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
+github.com/avast/retry-go/v4 v4.6.1 h1:VkOLRubHdisGrHnTu89g08aQEWEgRU7LVEop3GbIcMk=
+github.com/avast/retry-go/v4 v4.6.1/go.mod h1:V6oF8njAwxJ5gRo1Q7Cxab24xs5NCWZBeaHHBklR8mA=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=

--- a/pkg/types/tools/types.go
+++ b/pkg/types/tools/types.go
@@ -79,12 +79,10 @@ func StringifyToolResult(result, err string) string {
 </error>
 `, err)
 	}
-	if result != "" {
-		out += fmt.Sprintf(`<result>
-%s
-</result>
-`, result)
+	if result == "" {
+		result = "(No output)"
 	}
+	out += fmt.Sprintf("<result>\n%s\n</result>\n", result)
 	return out
 }
 


### PR DESCRIPTION
## Description
This PR implements a comprehensive retry mechanism for OpenAI API calls to improve reliability and handle transient failures. The implementation uses exponential backoff with intelligent error classification to automatically recover from temporary issues.

## Changes
- Add retry-go dependency for robust retry functionality  
- Implement intelligent error classification for 4xx/5xx HTTP status codes
- Add exponential backoff retry logic with 3 attempts, 1s initial delay, and 10s max delay
- Include structured logging for retry attempts to aid debugging
- Improve tool result formatting to always show output status
- Handle context cancellation and timeout errors appropriately (no retry)

## Impact
- Improved reliability by automatically recovering from transient API failures (rate limits, server errors)
- Enhanced user experience by reducing the need for manual retries during API outages  
- Better observability through structured logging of retry attempts
- More robust error handling for various failure scenarios