### PR TITLE
Security: Fix Vite vulnerabilities (dependabot alerts #6 and #7)

### DIFF
--- a/pkg/webui/frontend/package-lock.json
+++ b/pkg/webui/frontend/package-lock.json
@@ -40,7 +40,7 @@
         "postcss": "^8.4.35",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.2.2",
-        "vite": "^6.3.5",
+        "vite": "^6.3.6",
         "vitest": "^3.2.4"
       }
     },
@@ -1039,9 +1039,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1146,13 +1146,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.1",
+        "@eslint/core": "^0.15.2",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -5648,9 +5648,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/pkg/webui/frontend/package.json
+++ b/pkg/webui/frontend/package.json
@@ -48,7 +48,7 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.2.2",
-    "vite": "^6.3.5",
+    "vite": "^6.3.6",
     "vitest": "^3.2.4"
   }
 }


### PR DESCRIPTION
## Summary
This PR fixes two low-severity security vulnerabilities in Vite detected by dependabot:

### Fixed Issues
- **Alert #7**: CVE-2025-58751 - Vite middleware serving files with same prefix as public directory
- **Alert #6**: CVE-2025-58752 - Vite server.fs settings not applied to HTML files
- **Bonus**: Fixed @eslint/plugin-kit RegEx DoS vulnerability via npm audit fix

### Changes
- Upgraded Vite from 6.3.5 to 6.3.6 in pkg/webui/frontend/package.json
- Updated package-lock.json with the new dependency versions
- Ran `npm audit fix` to resolve additional vulnerability

### Impact
- These are low-severity vulnerabilities that primarily affect development servers exposed to the network
- The fixes ensure proper file serving restrictions are enforced
- No breaking changes expected as this is a patch version update

### Testing
- [x] Dependencies updated successfully
- [x] npm audit reports 0 vulnerabilities
- [x] Vite version confirmed as 6.3.6

Resolves dependabot alerts #6 and #7