### PR TITLE
docs: Add Homebrew installation instructions and improve install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,6 @@ Kodelet is a lightweight agentic SWE Agent. It runs as an interactive CLI tool i
 ### Via Homebrew (macOS/Linux)
 
 ```bash
-brew install jingkaihe/kodelet/kodelet
-```
-
-Or add the tap first:
-
-```bash
 brew tap jingkaihe/kodelet
 brew install kodelet
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,21 @@ Kodelet is a lightweight agentic SWE Agent. It runs as an interactive CLI tool i
 
 ## Installation
 
+### Via Homebrew (macOS/Linux)
+
+```bash
+brew install jingkaihe/kodelet/kodelet
+```
+
+Or add the tap first:
+
+```bash
+brew tap jingkaihe/kodelet
+brew install kodelet
+```
+
+### Via Install Script
+
 ```bash
 curl -sSL https://raw.githubusercontent.com/jingkaihe/kodelet/main/install.sh | bash
 ```

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,7 @@ echo -e "${GREEN}Detected architecture: $ARCH${NC}"
 echo -e "${GREEN}Installing version: $VERSION${NC}"
 
 # Create installation directory
-INSTALL_DIR="$HOME/.kodelet"
+INSTALL_DIR="$HOME/.local"
 mkdir -p "$INSTALL_DIR/bin"
 
 # Download URL construction
@@ -107,9 +107,9 @@ else
         EXPORT_CMD="export PATH=\$PATH:$INSTALL_DIR/bin"
     fi
 
-    # Check if the path is already in the profile
-    if [ -f "$PROFILE_FILE" ] && grep -q "$INSTALL_DIR/bin" "$PROFILE_FILE"; then
-        echo -e "${GREEN}Path already in $PROFILE_FILE${NC}"
+    # Check if the path is already in $PATH
+    if echo "$PATH" | grep -q "$INSTALL_DIR/bin"; then
+        echo -e "${GREEN}$INSTALL_DIR/bin is already in your PATH${NC}"
     else
         # Add the PATH export to shell profile
         echo "" >> "$PROFILE_FILE"


### PR DESCRIPTION
## Description
This PR adds Homebrew installation instructions to the README, making it easier for macOS and Linux users to install Kodelet. Additionally, it improves the install script by using a more standard installation directory and enhancing the PATH checking logic.

## Changes
- Added Homebrew installation section to README.md with both direct install and tap-based installation methods
- Changed installation directory from `~/.kodelet` to `~/.local` to better follow XDG Base Directory specifications
- Improved PATH checking logic in install.sh to verify if the directory is already in $PATH before adding to shell profile

## Impact
- Users can now install Kodelet via Homebrew, providing a more convenient and familiar installation method for macOS/Linux users
- Installation follows standard Unix conventions by using `~/.local` as the installation directory
- Better user experience with improved PATH detection that avoids unnecessary profile modifications